### PR TITLE
text-placement: interior

### DIFF
--- a/cphbikes/labels.mss
+++ b/cphbikes/labels.mss
@@ -45,7 +45,7 @@
 	text-face-name: 'Arial Italic';
 	text-fill: #fff;
 	text-halo-fill: @water;
-	text-placement: point;
+	text-placement: interior;
 	text-max-char-angle-delta: 30;
 	text-wrap-width: 40;
 	text-halo-radius: 2;


### PR DESCRIPTION
This tells Mapnik to attempt to place labels for polygons within their interior rather than at their centroid.  This improves rendering of U-shaped polygons (see #77).
